### PR TITLE
Fix REST module formatFilesArray function

### DIFF
--- a/src/Codeception/Module/REST.php
+++ b/src/Codeception/Module/REST.php
@@ -583,13 +583,13 @@ EOF;
                 if (isset($value['tmp_name'])) {
                     $this->checkFileBeforeUpload($value['tmp_name']);
                     if (!isset($value['name'])) {
-                        $value['name'] = basename($value);
+                        $value['name'] = basename($value['tmp_name']);
                     }
                     if (!isset($value['size'])) {
-                        $value['size'] = filesize($value);
+                        $value['size'] = filesize($value['tmp_name']);
                     }
                     if (!isset($value['type'])) {
-                        $value['type'] = $this->getFileType($value);
+                        $value['type'] = $this->getFileType($value['tmp_name']);
                     }
                     if (!isset($value['error'])) {
                         $value['error'] = 0;


### PR DESCRIPTION
Fixed an issue when passing a file to sendPOST() method without name, size or type parameter.
Reproduced by:
```php
$I->sendPOST('url', [], [
  'uploadedFile' => [
    'tmp_name' => 'path to existing file',
  ],
]);
```